### PR TITLE
Exclude default resolvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "aws-xray-sdk-core": "^1.3.0",
-    "graphql-middleware": "^1.2.5",
+    "graphql-middleware": "^1.5.0",
     "is-promise": "^2.1.0"
   },
   "publishConfig": {

--- a/src/traceResolvers.js
+++ b/src/traceResolvers.js
@@ -1,4 +1,4 @@
-const { applyMiddleware } = require('graphql-middleware');
+const { applyMiddlewareToDeclaredResolvers } = require('graphql-middleware');
 const AWSXRay = require('aws-xray-sdk-core');
 const isPromise = require('is-promise');
 
@@ -39,5 +39,5 @@ const tracer = function (resolver, parent, args, ctx, info) {
 };
 
 module.exports = function (schema) {
-  applyMiddleware(schema, tracer);
+  applyMiddlewareToDeclaredResolvers(schema, tracer);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,9 +2065,9 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-graphql-middleware@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-1.2.5.tgz#f68c0c399cf573a6334d1d9e04cddfec038ffd4a"
+graphql-middleware@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-1.5.0.tgz#b539cbc34df8ea7b077415102e87fd704188d7ec"
   dependencies:
     graphql-tools "^3.0.2"
 


### PR DESCRIPTION
Before this change, an X-Ray segment was created for every single attribute in the GraphQL query. That level of detail is not good for a couple of reasons:

 1. The default attribute lookup resolvers all complete in 0ms since almost no work is done
 2. The X-Ray trace gets so full of default resolvers that it's hard to find the ones that are interesting
 3. The overhead of reporting all of those resolvers leads to extra network and CPU overhead. 