### PR TITLE
Upgrade eslint related plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "LifeOmic <development@lifeomic.com>",
   "license": "MIT",
   "devDependencies": {
-    "@lifeomic/eslint-plugin-node": "^1.1.1",
+    "@lifeomic/eslint-plugin-node": "^1.1.2",
     "ava": "^0.25.0",
     "coveralls": "^3.0.1",
     "eslint": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,12 +133,12 @@
     pretty-ms "^0.2.1"
     text-table "^0.2.0"
 
-"@lifeomic/eslint-plugin-node@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@lifeomic/eslint-plugin-node/-/eslint-plugin-node-1.1.1.tgz#514cfd5dbb8610efe70c17218d55cba548f6554c"
+"@lifeomic/eslint-plugin-node@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@lifeomic/eslint-plugin-node/-/eslint-plugin-node-1.1.2.tgz#e422073bd288695baef95237a8b51935dbf10dcd"
   dependencies:
-    eslint-config-semistandard "^11.0.0"
-    eslint-config-standard "^10.0.0"
+    eslint-config-semistandard "^12.0.1"
+    eslint-config-standard "^11.0.0"
     eslint-plugin-import "^2.8.0"
     eslint-plugin-lodash "^2.6.1"
     eslint-plugin-node "^6.0.0"
@@ -1514,13 +1514,13 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-eslint-config-semistandard@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-semistandard/-/eslint-config-semistandard-11.0.0.tgz#44eef7cfdfd47219e3a7b81b91b540e880bb2615"
+eslint-config-semistandard@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-semistandard/-/eslint-config-semistandard-12.0.1.tgz#e35d66959dfe6f0d8e8445d7a4de37d8fd8875f4"
 
-eslint-config-standard@^10.0.0:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz#c061e4d066f379dc17cd562c64e819b4dd454591"
+eslint-config-standard@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz#87ee0d3c9d95382dc761958cbb23da9eea31e0ba"
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
@@ -1537,8 +1537,8 @@ eslint-module-utils@^2.2.0:
     pkg-dir "^1.0.0"
 
 eslint-plugin-import@^2.8.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz#df24f241175e312d91662dc91ca84064caec14ed"
   dependencies:
     contains-path "^0.1.0"
     debug "^2.6.8"


### PR DESCRIPTION
These upgrades fix the following console warnings:

```
warning " > @lifeomic/eslint-plugin-node@1.1.1" has incorrect peer dependency "eslint@^4.0.0".
warning "@lifeomic/eslint-plugin-node > eslint-plugin-import@2.12.0" has incorrect peer dependency "eslint@2.x - 4.x".
```
