### PR TITLE
Disable xray logs in integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/graphql-resolvers-xray-tracing",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A GraphQL middleware to enable X-Ray tracing subsegments for GraphQL resolvers",
   "homepage": "https://github.com/lifeomic/graphql-resolvers-xray-tracing#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/graphql-resolvers-xray-tracing",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A GraphQL middleware to enable X-Ray tracing subsegments for GraphQL resolvers",
   "homepage": "https://github.com/lifeomic/graphql-resolvers-xray-tracing#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/graphql-resolvers-xray-tracing",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "A GraphQL middleware to enable X-Ray tracing subsegments for GraphQL resolvers",
   "homepage": "https://github.com/lifeomic/graphql-resolvers-xray-tracing#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/graphql-resolvers-xray-tracing",
-  "version": "2.2.0",
+  "version": "2.0.0",
   "description": "A GraphQL middleware to enable X-Ray tracing subsegments for GraphQL resolvers",
   "homepage": "https://github.com/lifeomic/graphql-resolvers-xray-tracing#readme",
   "bugs": {

--- a/src/traceResolvers.js
+++ b/src/traceResolvers.js
@@ -14,16 +14,14 @@ function fieldPathFromInfo (info) {
 }
 
 const tracer = function (resolver, parent, args, ctx, info) {
-  if (process.env.DISABLE_XRAY_LOGGING) {
-    return resolver();
-  }
   let result;
+
   const fieldPath = fieldPathFromInfo(info);
   AWSXRay.captureAsyncFunc(`GraphQL ${fieldPath}`, function (subsegment) {
     result = resolver();
-    // Note 1: When AWS_XRAY_CONTEXT_MISSING is set to LOG_MISSING and no context was
+
+    // When AWS_XRAY_CONTEXT_MISSING is set to LOG_MISSING and no context was
     // found, then the subsegment will be null and nothing should be done
-    // Note 2: We don't trace requests during integration tests since it makes logs unreadable
     if (subsegment) {
       if (isPromise(result)) {
         result.then(function () {

--- a/src/traceResolvers.js
+++ b/src/traceResolvers.js
@@ -14,14 +14,16 @@ function fieldPathFromInfo (info) {
 }
 
 const tracer = function (resolver, parent, args, ctx, info) {
+  if (process.env.DISABLE_XRAY_LOGGING) {
+    return resolver();
+  }
   let result;
-
   const fieldPath = fieldPathFromInfo(info);
   AWSXRay.captureAsyncFunc(`GraphQL ${fieldPath}`, function (subsegment) {
     result = resolver();
-
-    // When AWS_XRAY_CONTEXT_MISSING is set to LOG_MISSING and no context was
+    // Note 1: When AWS_XRAY_CONTEXT_MISSING is set to LOG_MISSING and no context was
     // found, then the subsegment will be null and nothing should be done
+    // Note 2: We don't trace requests during integration tests since it makes logs unreadable
     if (subsegment) {
       if (isPromise(result)) {
         result.then(function () {

--- a/src/traceResolvers.js
+++ b/src/traceResolvers.js
@@ -14,7 +14,7 @@ function fieldPathFromInfo (info) {
 }
 
 const tracer = function (resolver, parent, args, ctx, info) {
-  if (process.env.DISABLE_XRAY_LOGGING) {
+  if (process.env.DISABLE_XRAY) {
     return resolver();
   }
   let result;

--- a/test/traceResolvers.test.js
+++ b/test/traceResolvers.test.js
@@ -40,6 +40,22 @@ function waitForSegmentCount (test, count) {
   }, {retries: 10, minTimeout: 10, maxTimeout: 100});
 }
 
+test.serial('Resolvers can return a value when DISABLE_XRAY_LOGGING is set', async function (test) {
+  process.env.DISABLE_XRAY_LOGGING = true;
+  const {graphql} = test.context;
+  const result = await graphql('{ hello }');
+
+  if (result.errors) {
+    throw result.errors[0];
+  }
+  test.deepEqual(result, {
+    data: {
+      hello: 'world'
+    }
+  });
+  delete process.env.DISABLE_XRAY_LOGGING;
+});
+
 test('Traced resolvers can return a value', async function (test) {
   const {graphql} = test.context;
   const result = await graphql('{ hello }');

--- a/test/traceResolvers.test.js
+++ b/test/traceResolvers.test.js
@@ -42,18 +42,23 @@ function waitForSegmentCount (test, count) {
 
 test.serial('Resolvers can return a value when DISABLE_XRAY is set', async function (test) {
   process.env.DISABLE_XRAY = true;
-  const {graphql} = test.context;
-  const result = await graphql('{ hello }');
+  try {
+    const {graphql} = test.context;
+    const result = await graphql('{ hello }');
 
-  if (result.errors) {
-    throw result.errors[0];
-  }
-  test.deepEqual(result, {
-    data: {
-      hello: 'world'
+    if (result.errors) {
+      throw result.errors[0];
     }
-  });
-  delete process.env.DISABLE_XRAY;
+    test.deepEqual(result, {
+      data: {
+        hello: 'world'
+      }
+    });
+  } catch (err) {
+    test.fail(err);
+  } finally {
+    delete process.env.DISABLE_XRAY;
+  }
 });
 
 test('Traced resolvers can return a value', async function (test) {

--- a/test/traceResolvers.test.js
+++ b/test/traceResolvers.test.js
@@ -40,22 +40,6 @@ function waitForSegmentCount (test, count) {
   }, {retries: 10, minTimeout: 10, maxTimeout: 100});
 }
 
-test.serial('Resolvers can return a value when DISABLE_XRAY_LOGGING is set', async function (test) {
-  process.env.DISABLE_XRAY_LOGGING = true;
-  const {graphql} = test.context;
-  const result = await graphql('{ hello }');
-
-  if (result.errors) {
-    throw result.errors[0];
-  }
-  test.deepEqual(result, {
-    data: {
-      hello: 'world'
-    }
-  });
-  delete process.env.DISABLE_XRAY_LOGGING;
-});
-
 test('Traced resolvers can return a value', async function (test) {
   const {graphql} = test.context;
   const result = await graphql('{ hello }');

--- a/test/traceResolvers.test.js
+++ b/test/traceResolvers.test.js
@@ -40,8 +40,8 @@ function waitForSegmentCount (test, count) {
   }, {retries: 10, minTimeout: 10, maxTimeout: 100});
 }
 
-test.serial('Resolvers can return a value when DISABLE_XRAY_LOGGING is set', async function (test) {
-  process.env.DISABLE_XRAY_LOGGING = true;
+test.serial('Resolvers can return a value when DISABLE_XRAY is set', async function (test) {
+  process.env.DISABLE_XRAY = true;
   const {graphql} = test.context;
   const result = await graphql('{ hello }');
 
@@ -53,7 +53,7 @@ test.serial('Resolvers can return a value when DISABLE_XRAY_LOGGING is set', asy
       hello: 'world'
     }
   });
-  delete process.env.DISABLE_XRAY_LOGGING;
+  delete process.env.DISABLE_XRAY;
 });
 
 test('Traced resolvers can return a value', async function (test) {


### PR DESCRIPTION
I was also considering disabling xray logs based on process.env.ENVIRONMENT === ‘integration-test’, but I thought I would rather introduce a new variable in case some project uses a different name for their integration env, or in case some project actually wants to have x-ray logs enabled

Related review:
https://bitbucket.org/lifeomic/koa/pull-requests/94/disable-xray-logs-in-integration-tests/diff

Also, I have accidentally pushed this to master directly, and then pushed a revert commit. Hopefully, this is not a big issue.