### PR TITLE
Updated readme with threshold info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
 ```
 
 ## AWS Segment Size Limitation
-AWS has a 64K upload limit when submitting segements to AWS see [](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-segments).  If you try and submit more than this limit you will see the follow aws error message "<date> [ERROR] Segment too large to send: {<traceinformation...}".  One approach to reduce the size of the batch upload, is to [Node - setStreamingThreshold](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).  
+AWS has a 64K upload limit when submitting segements to AWS see [AWSXRay concepts segments](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-segments).  If you try and submit more than this limit you will see the follow aws error message "<date> [ERROR] Segment too large to send: {<traceinformation...}".  One approach to remove this error, is to reduce the size of the batch upload (eg.. setStreamingThreshold(0) which will send each subsegment on close). See [Node - setStreamingThreshold](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).  

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
   traceResolvers(schema);
 }
 ```
+
+## AWS Segment Size Limitation
+AWS has a 64K upload limit when submitting segements to AWS see [](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-segments).  If you try and submit more than this limit you will see the follow aws error message "<date> [ERROR] Segment too large to send: {<traceinformation...}".  One approach to reduce the size of the batch upload, is to [Node - setStreamingThreshold](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).  

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
 ## AWS Segment Size Limitation
 AWS has a 64K upload limit when submitting segements to AWS see [AWSXRay concepts segments](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-segments).  
 
-If you try and submit more than this limit you will see the follow aws error message **"<date> [ERROR] Segment too large to send: {<traceinformation...}"**
+If you try and submit more than this limit you will see the following aws error message 
+    **"<date> [ERROR] Segment too large to send: {<traceinformation...}"**
   
 One approach to remove this error, is to reduce the size of the batch upload (eg.. setStreamingThreshold(0) which will send each subsegment on close). See [Node - setStreamingThreshold](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).  

--- a/README.md
+++ b/README.md
@@ -31,4 +31,8 @@ if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
 ```
 
 ## AWS Segment Size Limitation
-AWS has a 64K upload limit when submitting segements to AWS see [AWSXRay concepts segments](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-segments).  If you try and submit more than this limit you will see the follow aws error message "<date> [ERROR] Segment too large to send: {<traceinformation...}".  One approach to remove this error, is to reduce the size of the batch upload (eg.. setStreamingThreshold(0) which will send each subsegment on close). See [Node - setStreamingThreshold](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).  
+AWS has a 64K upload limit when submitting segements to AWS see [AWSXRay concepts segments](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-segments).  
+
+If you try and submit more than this limit you will see the follow aws error message **"<date> [ERROR] Segment too large to send: {<traceinformation...}"**
+  
+One approach to remove this error, is to reduce the size of the batch upload (eg.. setStreamingThreshold(0) which will send each subsegment on close). See [Node - setStreamingThreshold](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).  

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
 ## AWS Segment Size Limitation
 AWS has a 64K upload limit when submitting segements to AWS see [AWSXRay concepts segments](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-segments).  
 
-If you try and submit more than this limit you will see the following aws error message 
-    **"<date> [ERROR] Segment too large to send: {<traceinformation...}"**
+If you try and submit more than this limit you will see the following aws error message<br>**"<date> [ERROR] Segment too large to send: {<traceinformation...}"**
   
-One approach to remove this error, is to reduce the size of the batch upload (eg.. setStreamingThreshold(0) which will send each subsegment on close). See [Node - setStreamingThreshold](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).  
+One approach to remove this error, is to reduce the size of the batch upload (eg.. setStreamingThreshold(0) which will send each subsegment on close). See [SDK - nodejs - setStreamingThreshold](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).  


### PR DESCRIPTION
Updated the readme to help others when observing the "Segement too large to send" error message in aws.