### PR TITLE
Don't run types on install, just before test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/graphql-resolvers-xray-tracing",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "A GraphQL middleware to enable X-Ray tracing subsegments for GraphQL resolvers",
   "homepage": "https://github.com/lifeomic/graphql-resolvers-xray-tracing#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "pretest": "yarn types",
     "test": "nyc ava",
     "posttest": "yarn lint && tsc --noEmit",
-    "postinstall": "if [ -d test ]; then yarn types; fi",
     "coverage": "nyc report --reporter=text-lcov > ./.nyc_output/lcov.info",
     "prepublishOnly": "yarn tsc",
     "cleanTypes": "rm -rf test/__generated__"


### PR DESCRIPTION
The `-d` doesn't appear to work on Windows installs.

Fixes #73 

![os](https://media.giphy.com/media/3oEdv3r2JssXPD7QeQ/giphy.gif)